### PR TITLE
Fixes that enable integration with WAAD

### DIFF
--- a/JabbR/App_Start/FederatedLogin.Hooks.cs
+++ b/JabbR/App_Start/FederatedLogin.Hooks.cs
@@ -59,7 +59,7 @@ namespace JabbR.App_Start
              //   }
 
                 string userIdentity = userIdentityClaim.Value;
-                string username = _firstname + "" + _lastname;
+                string username = _firstname;
                 string email = _email;
                 Claim emailClaim = identity.Claims.SingleOrDefault(c => c.ClaimType == ClaimTypes.Email);
                 if (emailClaim != null)

--- a/JabbR/App_Start/FederatedLogin.Hooks.cs
+++ b/JabbR/App_Start/FederatedLogin.Hooks.cs
@@ -9,6 +9,9 @@ namespace JabbR.App_Start
 {
     public static partial class FederatedLogin
     {
+
+        
+
         private partial class NoConfigWSFederationAuthenticationModule 
         {
             protected override void OnSignedIn(EventArgs args)
@@ -21,6 +24,7 @@ namespace JabbR.App_Start
             public void ProcessRequest(HttpContext context)
             {
                 IClaimsIdentity identity = context.User.Identity as IClaimsIdentity;
+                string _domain = "", _email = "", _firstname="", _lastname="", _strClaimType;
 
                 if (identity == null)
                 {
@@ -33,14 +37,30 @@ namespace JabbR.App_Start
                     throw new InvalidOperationException("NameIdentifier claim not found.");
                 }
 
-                if (identity.Name == null)
-                {
-                    throw new InvalidOperationException("Name claim not found.");
-                }
+                // This runs through and forms the data for the claim. Obviously this can be done with Linq
+               foreach (var c in identity.Claims)
+            {
+                _strClaimType = c.ClaimType;
+                if (_strClaimType.EndsWith("domain"))
+                    _domain = c.Value;
+                if (_strClaimType.EndsWith("EmailAddress"))
+                    _email = c.Value;
+                if (_strClaimType.EndsWith("FirstName"))
+                      _firstname = c.Value;
+                if (_strClaimType.EndsWith("LastName"))
+                       _lastname = c.Value ;
+            }
+
+            // Name does not exist in the Claim coming from ACS at this point in time
+
+             //   if (identity.Name == null)
+             //   {
+             //       throw new InvalidOperationException("Name claim not found.");
+             //   }
 
                 string userIdentity = userIdentityClaim.Value;
-                string username = identity.Name;
-                string email = String.Empty;
+                string username = _firstname + "" + _lastname;
+                string email = _email;
                 Claim emailClaim = identity.Claims.SingleOrDefault(c => c.ClaimType == ClaimTypes.Email);
                 if (emailClaim != null)
                 {

--- a/JabbR/App_Start/FederatedLogin.cs
+++ b/JabbR/App_Start/FederatedLogin.cs
@@ -52,6 +52,7 @@ namespace JabbR.App_Start
 
                 this.Realm = settings.FedAuthRealm;
                 this.Issuer = settings.FedAuthIdentityProviderUrl;
+                this.Reply = settings.FedAuthReply;
                 // if not using the idp selector, redirect straight to idp if not authenticated
                 this.PassiveRedirectEnabled = !settings.FedAuthWindowsAzureActiveDirectorySelectorEnabled; 
                 this.RequireHttps = settings.FedAuthRequiresSsl;

--- a/JabbR/JabbR.csproj
+++ b/JabbR/JabbR.csproj
@@ -21,10 +21,10 @@
     </FileUpgradeFlags>
     <OldToolsVersion>4.0</OldToolsVersion>
     <UpgradeBackupLocation />
-    <IISExpressSSLPort />
-    <IISExpressAnonymousAuthentication />
-    <IISExpressWindowsAuthentication />
-    <IISExpressUseClassicPipelineMode />
+    <IISExpressSSLPort>44300</IISExpressSSLPort>
+    <IISExpressAnonymousAuthentication>enabled</IISExpressAnonymousAuthentication>
+    <IISExpressWindowsAuthentication>disabled</IISExpressWindowsAuthentication>
+    <IISExpressUseClassicPipelineMode>false</IISExpressUseClassicPipelineMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/JabbR/Services/ApplicationSettings.cs
+++ b/JabbR/Services/ApplicationSettings.cs
@@ -55,6 +55,7 @@ namespace JabbR.Services
             }
         }
 
+
         public string FedAuthCertificateThumbprint
         {
             get
@@ -80,6 +81,14 @@ namespace JabbR.Services
                 bool selectorEnabled = false;
                 bool selectorEnabledParsed = Boolean.TryParse(ConfigurationManager.AppSettings["fedauth.waad.selectorEnabled"], out selectorEnabled);
                 return selectorEnabledParsed && selectorEnabled;
+            }
+        }
+
+        public string FedAuthReply
+        {
+            get
+            {
+                return ConfigurationManager.AppSettings["fedauth.waad.reply"];
             }
         }
     }

--- a/JabbR/Services/IApplicationSettings.cs
+++ b/JabbR/Services/IApplicationSettings.cs
@@ -12,6 +12,7 @@ namespace JabbR.Services
 
         string FedAuthIdentityProviderUrl { get; }
         string FedAuthRealm { get; }
+        string FedAuthReply { get; }
         string FedAuthCertificateThumbprint { get; }
         bool FedAuthRequiresSsl { get; }
         bool FedAuthWindowsAzureActiveDirectorySelectorEnabled { get; }

--- a/JabbR/Web.config
+++ b/JabbR/Web.config
@@ -32,15 +32,15 @@
     <add key="auth.appId" value="" />
 
     <!-- federated identity configuration for enterprise sso (ADFS, SiteMinder, Ping, Windows Azure Active Directory, etc.) -->
-    <add key="fedauth.identityProviderUrl" value="" />
-    <add key="fedauth.realm" value="" />
-    <add key="fedauth.certThumbprint" value="" />
+    <add key="fedauth.identityProviderUrl" value="https://accounts.accesscontrol.windows.net/v2/wsfederation" />
+    <add key="fedauth.realm" value="spn:c732357d-f531-4378-b4f1-5d203a38050b@e4073280-196b-408f-9d40-0be89978fda0" />
+    <add key="fedauth.certThumbprint" value="3464C5BDD2BE7F2B6112E2F08E9C0024E33D9FE0" />
     <add key="fedauth.requireSsl" value="false" />
     <!-- NOTE: this feature only works if you are using Windows Azure Active Directory (also known as ACS)
               true = will show the modal identity provider selector, false = will redirect to WAAD (uncomment authorization section as well) -->
     <add key="fedauth.waad.selectorEnabled" value="false" />
-    <add key="fedauth.waad.namespace" value="" />
-    <add key="fedauth.waad.reply" value="" />
+    <add key="fedauth.waad.namespace" value="werner.onmicrosoft.com" />
+    <add key="fedauth.waad.reply" value="https://localhost:44300/" />
   </appSettings>
   <elmah>
     <errorFilter>
@@ -66,9 +66,9 @@
     </httpHandlers>
     <authentication mode="None" />
     <!-- comment this if you want to show the identity selctor (fedauth.waad.selectorEnabled = true)-->
-    <!--<authorization>
+    <authorization>
       <deny users="?" />
-    </authorization>-->
+    </authorization>
   </system.web>
   <system.webServer>
     <modules runAllManagedModulesForAllRequests="true">

--- a/JabbR/Web.config
+++ b/JabbR/Web.config
@@ -66,9 +66,9 @@
     </httpHandlers>
     <authentication mode="None" />
     <!-- comment this if you want to show the identity selctor (fedauth.waad.selectorEnabled = true)-->
-    <authorization>
+     <authorization>
       <deny users="?" />
-    </authorization>
+    </authorization> 
   </system.web>
   <system.webServer>
     <modules runAllManagedModulesForAllRequests="true">

--- a/JabbR/Web.config
+++ b/JabbR/Web.config
@@ -40,6 +40,7 @@
               true = will show the modal identity provider selector, false = will redirect to WAAD (uncomment authorization section as well) -->
     <add key="fedauth.waad.selectorEnabled" value="false" />
     <add key="fedauth.waad.namespace" value="" />
+    <add key="fedauth.waad.reply" value="" />
   </appSettings>
   <elmah>
     <errorFilter>


### PR DESCRIPTION
- Added fedauth.waad.reply in web.config for configuration needs
- Added changes to ApplicationSettings.cs to support this in WIF
- Removed finding by identity.Name (does not exist in an ACS token) in FederatedLogin.Hooks.cs
- Added parsing so that Firstname / Lastname / Email can be found in Claim in FederatedLogin.Hooks.cs

NOTE: Did it the messy way, can be cleaned up by Linq if we switch to .Net 4.5 and use System.Identity

This could easily break Ping and others working, and I think it may be best to do some property that changes depending on if it is configured to work against WAAD or a SAML 1.1 provider like Ping.

Thoughts?
